### PR TITLE
Fix #1. Use the default version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN mkdir /build &&                                                 \
     git clone https://github.com/GregorR/musl-cross.git &&          \
     cd musl-cross &&                                                \
     echo 'GCC_BUILTIN_PREREQS=yes' >> config.sh &&                  \
-    sed -i -e "s/^MUSL_VERSION=.*\$/MUSL_VERSION=1.1.12/" defs.sh &&  \
     ./build.sh &&                                                   \
     cd / &&                                                         \
     apt-get clean &&                                                \


### PR DESCRIPTION
Fix #1 , Version 1.1.12 is not included in the master branch of [musl-cross](https://github.com/GregorR/musl-cross)